### PR TITLE
fix techreborn dependency

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -42,6 +42,6 @@
   "depends": {
     "fabric": "*",
     "minecraft": "1.15.x",
-    "techreborn": "3.3.6+build.207"
+    "techreborn": ">=3.3.6+build.207"
   }
 }


### PR DESCRIPTION
This makes Lint work with any TechReborn version 3.3.6+build.207 *or greater*, since version 3.3.6+build.207 is not and will not be on curseforge.